### PR TITLE
Add Project Updates management: Cancel job and get informations

### DIFF
--- a/awx.go
+++ b/awx.go
@@ -2,9 +2,10 @@ package awx
 
 import (
 	"fmt"
-	"github.com/kylelemons/godebug/pretty"
 	"net/http"
 	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
 )
 
 // This variable is mandatory and to be populated for creating services API
@@ -15,14 +16,15 @@ var mandatoryFields = []string{}
 type AWX struct {
 	client *Client
 
-	PingService        *PingService
-	InventoriesService *InventoriesService
-	JobService         *JobService
-	JobTemplateService *JobTemplateService
-	ProjectService     *ProjectService
-	UserService        *UserService
-	GroupService       *GroupService
-	HostService        *HostService
+	PingService           *PingService
+	InventoriesService    *InventoriesService
+	JobService            *JobService
+	JobTemplateService    *JobTemplateService
+	ProjectService        *ProjectService
+	ProjectUpdatesService *ProjectUpdatesService
+	UserService           *UserService
+	GroupService          *GroupService
+	HostService           *HostService
 }
 
 // Client implement http client.
@@ -90,6 +92,9 @@ func NewAWX(baseURL, userName, passwd string, client *http.Client) *AWX {
 			client: awxClient,
 		},
 		ProjectService: &ProjectService{
+			client: awxClient,
+		},
+		ProjectUpdatesService: &ProjectUpdatesService{
 			client: awxClient,
 		},
 		UserService: &UserService{

--- a/awxtesting/mockserver/mockdata/project_updates.go
+++ b/awxtesting/mockserver/mockdata/project_updates.go
@@ -1,0 +1,147 @@
+package mockdata
+
+var (
+	// MockedProjectUpdateCancelResponse mocked `ProjectUpdateCancel` endpoint response
+	MockedProjectUpdateCancelResponse = []byte(`{
+        "can_cancel": true
+    }`)
+
+	// MockedProjectUpdateGetResponse mocked `ProjectUpdateGet` endpoint response
+	MockedProjectUpdateGetResponse = []byte(`
+        {
+            "id": 301,
+            "type": "job",
+            "url": "/api/v2/jobs/301/",
+            "related": {
+                "created_by": "/api/v2/users/1/",
+                "labels": "/api/v2/jobs/301/labels/",
+                "inventory": "/api/v2/inventories/1/",
+                "project": "/api/v2/projects/6/",
+                "extra_credentials": "/api/v2/jobs/301/extra_credentials/",
+                "credentials": "/api/v2/jobs/301/credentials/",
+                "unified_job_template": "/api/v2/job_templates/8/",
+                "stdout": "/api/v2/jobs/301/stdout/",
+                "notifications": "/api/v2/jobs/301/notifications/",
+                "job_host_summaries": "/api/v2/jobs/301/job_host_summaries/",
+                "job_events": "/api/v2/jobs/301/job_events/",
+                "activity_stream": "/api/v2/jobs/301/activity_stream/",
+                "job_template": "/api/v2/job_templates/8/",
+                "cancel": "/api/v2/jobs/301/cancel/",
+                "project_update": "/api/v2/project_updates/303/",
+                "create_schedule": "/api/v2/jobs/301/create_schedule/",
+                "relaunch": "/api/v2/jobs/301/relaunch/"
+            },
+            "summary_fields": {
+                "instance_group": {
+                    "id": 1,
+                    "name": "tower"
+                },
+                "job_template": {
+                    "id": 8,
+                    "name": "Hello-world",
+                    "description": ""
+                },
+                "inventory": {
+                    "id": 1,
+                    "name": "Demo Inventory",
+                    "description": "",
+                    "has_active_failures": false,
+                    "total_hosts": 2,
+                    "hosts_with_active_failures": 0,
+                    "total_groups": 0,
+                    "groups_with_active_failures": 0,
+                    "has_inventory_sources": false,
+                    "total_inventory_sources": 0,
+                    "inventory_sources_with_failures": 0,
+                    "organization_id": 1,
+                    "kind": ""
+                },
+                "project_update": {
+                    "id": 303,
+                    "name": "DeployBook",
+                    "description": "",
+                    "status": "successful",
+                    "failed": false
+                },
+                "unified_job_template": {
+                    "id": 8,
+                    "name": "Hello-world",
+                    "description": "",
+                    "unified_job_type": "job"
+                },
+                "project": {
+                    "id": 6,
+                    "name": "DeployBook",
+                    "description": "",
+                    "status": "successful",
+                    "scm_type": "git"
+                },
+                "created_by": {
+                    "id": 1,
+                    "username": "admin",
+                    "first_name": "",
+                    "last_name": ""
+                },
+                "user_capabilities": {
+                    "start": true,
+                    "delete": true
+                },
+                "labels": {
+                    "count": 0,
+                    "results": []
+                },
+                "extra_credentials": [],
+                "credentials": []
+            },
+            "created": "2018-06-05T09:13:43.046077Z",
+            "modified": "2018-06-05T09:13:49.132905Z",
+            "name": "Hello-world",
+            "description": "",
+            "job_type": "run",
+            "inventory": 1,
+            "project": 6,
+            "playbook": "hello-world.yml",
+            "forks": 0,
+            "limit": "localhost",
+            "verbosity": 0,
+            "extra_vars": "{}",
+            "job_tags": "",
+            "force_handlers": false,
+            "skip_tags": "",
+            "start_at_task": "",
+            "timeout": 0,
+            "use_fact_cache": false,
+            "unified_job_template": 8,
+            "launch_type": "manual",
+            "status": "canceled",
+            "failed": true,
+            "started": "2018-06-05T09:13:47.060276Z",
+            "finished": "2018-06-05T09:13:54.740342Z",
+            "elapsed": 7.68,
+            "job_args": "[\"ansible-playbook\", \"-i\", \"/tmp/awx_301_3kuP6Z/tmpupf88B\", \"-u\", \"root\", \"-l\", \"localhost\", \"-e\", \"@/tmp/awx_301_3kuP6Z/tmpjlw9Dp\", \"hello-world.yml\"]",
+            "job_cwd": "/var/lib/awx/projects/_6__deploybook",
+            "job_env": {},
+            "job_explanation": "",
+            "execution_node": "awx",
+            "result_traceback": "",
+            "event_processing_finished": true,
+            "job_template": 8,
+            "passwords_needed_to_start": [],
+            "ask_diff_mode_on_launch": false,
+            "ask_variables_on_launch": true,
+            "ask_limit_on_launch": true,
+            "ask_tags_on_launch": false,
+            "ask_skip_tags_on_launch": false,
+            "ask_job_type_on_launch": false,
+            "ask_verbosity_on_launch": false,
+            "ask_inventory_on_launch": true,
+            "ask_credential_on_launch": false,
+            "allow_simultaneous": false,
+            "artifacts": {},
+            "scm_revision": "ae9cc6b0fee9aea55e10a4a325c9ae3d97c42f1a",
+            "instance_group": 1,
+            "diff_mode": false,
+            "credential": null,
+            "vault_credential": null
+        }`)
+)

--- a/awxtesting/mockserver/mockserver.go
+++ b/awxtesting/mockserver/mockserver.go
@@ -146,6 +146,23 @@ func (s *mockServer) ProjectsHandler(rw http.ResponseWriter, req *http.Request) 
 	}
 }
 
+func (s *mockServer) ProjectUpdatesHandler(rw http.ResponseWriter, req *http.Request) {
+	var (
+		cancelJobUpdate = "/api/v2/project_updates/[0-9]+/cancel"
+		getJobUpdate    = "/api/v2/project_updates/[0-9]+"
+	)
+	if matched, _ := regexp.MatchString(cancelJobUpdate, req.URL.String()); matched {
+		result := mockdata.MockedProjectUpdateCancelResponse
+		rw.Write(result)
+		return
+	}
+	if matched, _ := regexp.MatchString(getJobUpdate, req.URL.String()); matched {
+		result := mockdata.MockedProjectUpdateGetResponse
+		rw.Write(result)
+		return
+	}
+}
+
 func (s *mockServer) UsersHandler(rw http.ResponseWriter, req *http.Request) {
 	switch {
 	case req.Method == "POST":
@@ -241,6 +258,7 @@ func initServer() {
 	mux.Handle("/api/v2/job_templates/", http.HandlerFunc(server.JobTemplatesHandler))
 	mux.Handle("/api/v2/jobs/", http.HandlerFunc(server.JobsHandler))
 	mux.Handle("/api/v2/projects/", http.HandlerFunc(server.ProjectsHandler))
+	mux.Handle("/api/v2/project_updates/", http.HandlerFunc(server.ProjectUpdatesHandler))
 	mux.Handle("/api/v2/users/", http.HandlerFunc(server.UsersHandler))
 	mux.Handle("/api/v2/groups/", http.HandlerFunc(server.GroupsHandler))
 	mux.Handle("/api/v2/hosts/", http.HandlerFunc(server.HostsHandler))

--- a/examples/project.md
+++ b/examples/project.md
@@ -24,7 +24,6 @@ func main() {
 }
 ```
 
-
 > Create Project
 
 ```go

--- a/examples/project_updates.md
+++ b/examples/project_updates.md
@@ -1,0 +1,45 @@
+# Project API
+
+## Usage
+
+> Project Updates Cancel
+
+```go
+package main
+import (
+    "log"
+    awxGo "github.com/Colstuwjx/awx-go"
+)
+
+func main() {
+    awx := awxGo.NewAWX("http://awx.your_server_host.com", "your_awx_username", "your_awx_passwd", nil)
+    err := awx.ProjectUpdatesService.ProjectUpdateCancel(4)
+
+    if err != nil {
+        log.Fatalf("Cancel Update Projects err: %s", err)
+    }
+
+    log.Printf("Update Project cancelled.")
+}
+```
+
+> Project Updates Get Update
+
+```go
+package main
+import (
+    "log"
+    awxGo "github.com/Colstuwjx/awx-go"
+)
+
+func main() {
+    awx := awxGo.NewAWX("http://awx.your_server_host.com", "your_awx_username", "your_awx_passwd", nil)
+    err := awx.ProjectUpdatesService.ProjectUpdateGet(4)
+
+    if err != nil {
+        log.Fatalf("Get Update Projects err: %s", err)
+    }
+
+    log.Printf("Get Project done.")
+}
+```

--- a/project_updates.go
+++ b/project_updates.go
@@ -1,0 +1,40 @@
+package awx
+
+import (
+	"fmt"
+)
+
+// ProjectUpdatesService implements awx projects apis.
+type ProjectUpdatesService struct {
+	client *Client
+}
+
+// ProjectUpdateCancel cancel of awx projects update.
+func (p *ProjectUpdatesService) ProjectUpdateCancel(id int) (*ProjectUpdateCancel, error) {
+	result := new(ProjectUpdateCancel)
+	endpoint := fmt.Sprintf("/api/v2/project_updates/%d/cancel", id)
+	resp, err := p.client.Requester.GetJSON(endpoint, result, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := CheckResponse(resp); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ProjectUpdateGet get of awx projects update.
+func (p *ProjectUpdatesService) ProjectUpdateGet(id int) (*Job, error) {
+	result := new(Job)
+	endpoint := fmt.Sprintf("/api/v2/project_updates/%d", id)
+	resp, err := p.client.Requester.GetJSON(endpoint, result, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := CheckResponse(resp); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/project_updates_test.go
+++ b/project_updates_test.go
@@ -1,0 +1,196 @@
+package awx
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProjectUpdateCancel(t *testing.T) {
+	var (
+		expectProjectUpdateCancelResponse = &ProjectUpdateCancel{
+			CanCancel: true,
+		}
+	)
+
+	awx := NewAWX(testAwxHost, testAwxUserName, testAwxPasswd, nil)
+	result, err := awx.ProjectUpdatesService.ProjectUpdateCancel(80)
+	if err != nil {
+		t.Fatalf("CancelUpdateProject err: %s", err)
+	} else {
+		checkAPICallResult(t, expectProjectUpdateCancelResponse, result)
+		t.Log("CancelUpdateProject passed!")
+	}
+}
+
+func TestProjectUpdateGet(t *testing.T) {
+	var (
+		expectProjectUpdateGetResponse = &Job{
+			ID:   301,
+			Type: "job",
+			URL:  "/api/v2/jobs/301/",
+			Related: &Related{
+				CreatedBy:          "/api/v2/users/1/",
+				Labels:             "/api/v2/jobs/301/labels/",
+				Inventory:          "/api/v2/inventories/1/",
+				Project:            "/api/v2/projects/6/",
+				ExtraCredentials:   "/api/v2/jobs/301/extra_credentials/",
+				Credentials:        "/api/v2/jobs/301/credentials/",
+				UnifiedJobTemplate: "/api/v2/job_templates/8/",
+				Stdout:             "/api/v2/jobs/301/stdout/",
+				Notifications:      "/api/v2/jobs/301/notifications/",
+				JobHostSummaries:   "/api/v2/jobs/301/job_host_summaries/",
+				JobEvents:          "/api/v2/jobs/301/job_events/",
+				ActivityStream:     "/api/v2/jobs/301/activity_stream/",
+				JobTemplate:        "/api/v2/job_templates/8/",
+				Cancel:             "/api/v2/jobs/301/cancel/",
+				ProjectUpdate:      "/api/v2/project_updates/303/",
+				CreateSchedule:     "/api/v2/jobs/301/create_schedule/",
+				Relaunch:           "/api/v2/jobs/301/relaunch/",
+			},
+			SummaryFields: &Summary{
+				InstanceGroup: &InstanceGroupSummary{
+					ID:   1,
+					Name: "tower",
+				},
+
+				JobTemplate: &JobTemplateSummary{
+					ID:          8,
+					Name:        "Hello-world",
+					Description: "",
+				},
+
+				Inventory: &Inventory{
+					ID:                           1,
+					Name:                         "Demo Inventory",
+					Description:                  "",
+					HasActiveFailures:            false,
+					TotalHosts:                   2,
+					HostsWithActiveFailures:      0,
+					TotalGroups:                  0,
+					GroupsWithActiveFailures:     0,
+					HasInventorySources:          false,
+					TotalInventorySources:        0,
+					InventorySourcesWithFailures: 0,
+					OrganizationID:               1,
+					Kind:                         "",
+				},
+
+				ProjectUpdate: &ProjectUpdate{
+					ID:          303,
+					Name:        "DeployBook",
+					Description: "",
+					Status:      "successful",
+					Failed:      false,
+				},
+
+				UnifiedJobTemplate: &UnifiedJobTemplate{
+					ID:             8,
+					Description:    "",
+					Name:           "Hello-world",
+					UnifiedJobType: "job",
+				},
+
+				Project: &Project{
+					ID:          6,
+					Name:        "DeployBook",
+					Description: "",
+					Status:      "successful",
+					ScmType:     "git",
+				},
+
+				CreatedBy: &ByUserSummary{
+					ID:        1,
+					Username:  "admin",
+					FirstName: "",
+					LastName:  "",
+				},
+
+				UserCapabilities: &UserCapabilities{
+					Start:  true,
+					Delete: true,
+				},
+
+				Labels: &Labels{
+					Count:   0,
+					Results: []interface{}{},
+				},
+
+				ExtraCredentials: []interface{}{},
+				Credentials:      []Credential{},
+			},
+
+			Created: func() time.Time {
+				t, _ := time.Parse(time.RFC3339, "2018-06-05T09:13:43.046077Z")
+				return t
+			}(),
+
+			Modified: func() time.Time {
+				t, _ := time.Parse(time.RFC3339, "2018-06-05T09:13:49.132905Z")
+				return t
+			}(),
+
+			Name:               "Hello-world",
+			Description:        "",
+			JobType:            "run",
+			Inventory:          1,
+			Project:            6,
+			Playbook:           "hello-world.yml",
+			Forks:              0,
+			Limit:              "localhost",
+			Verbosity:          0,
+			ExtraVars:          "{}",
+			JobTags:            "",
+			ForceHandlers:      false,
+			SkipTags:           "",
+			StartAtTask:        "",
+			Timeout:            0,
+			UseFactCache:       false,
+			UnifiedJobTemplate: 8,
+			LaunchType:         "manual",
+			Status:             "canceled",
+			Failed:             true,
+			Started: func() time.Time {
+				t, _ := time.Parse(time.RFC3339, "2018-06-05T09:13:47.060276Z")
+				return t
+			}(),
+			Finished: func() time.Time {
+				t, _ := time.Parse(time.RFC3339, "2018-06-05T09:13:54.740342Z")
+				return t
+			}(),
+			Elapsed:                 7.68,
+			JobArgs:                 "[\"ansible-playbook\", \"-i\", \"/tmp/awx_301_3kuP6Z/tmpupf88B\", \"-u\", \"root\", \"-l\", \"localhost\", \"-e\", \"@/tmp/awx_301_3kuP6Z/tmpjlw9Dp\", \"hello-world.yml\"]",
+			JobCwd:                  "/var/lib/awx/projects/_6__deploybook",
+			JobEnv:                  map[string]string{},
+			JobExplanation:          "",
+			ExecutionNode:           "awx",
+			ResultTraceback:         "",
+			EventProcessingFinished: true,
+			JobTemplate:             8,
+			PasswordsNeededToStart:  []interface{}{},
+			AskDiffModeOnLaunch:     false,
+			AskVariablesOnLaunch:    true,
+			AskLimitOnLaunch:        true,
+			AskTagsOnLaunch:         false,
+			AskSkipTagsOnLaunch:     false,
+			AskJobTypeOnLaunch:      false,
+			AskVerbosityOnLaunch:    false,
+			AskInventoryOnLaunch:    true,
+			AskCredentialOnLaunch:   false,
+			AllowSimultaneous:       false,
+			Artifacts:               map[string]string{},
+			ScmRevision:             "ae9cc6b0fee9aea55e10a4a325c9ae3d97c42f1a",
+			InstanceGroup:           1,
+			DiffMode:                false,
+			Credential:              nil,
+			VaultCredential:         nil,
+		}
+	)
+	awx := NewAWX(testAwxHost, testAwxUserName, testAwxPasswd, nil)
+	result, err := awx.ProjectUpdatesService.ProjectUpdateGet(301)
+	if err != nil {
+		t.Fatalf("ProjectUpdateGet err: %s", err)
+	} else {
+		checkAPICallResult(t, expectProjectUpdateGetResponse, result)
+		t.Log("ProjectUpdateGet passed!")
+	}
+}

--- a/types.go
+++ b/types.go
@@ -15,6 +15,11 @@ type Pagination struct {
 	Previous interface{} `json:"previous"`
 }
 
+// ProjectUpdateCancel represents the awx project update cancel api response.
+type ProjectUpdateCancel struct {
+	CanCancel bool `json:"can_cancel"`
+}
+
 // Related represents the awx api related field.
 type Related struct {
 	NamedURL                     string `json:"named_url"`
@@ -141,23 +146,26 @@ type Labels struct {
 
 // Summary represents the awx api summary fields.
 type Summary struct {
-	InstanceGroup      *InstanceGroupSummary `json:"instance_group"`
-	Organization       *OrgnizationSummary   `json:"organization"`
-	CreatedBy          *ByUserSummary        `json:"created_by"`
-	ModifiedBy         *ByUserSummary        `json:"modified_by"`
-	ObjectRoles        *ObjectRoles          `json:"object_roles"`
-	UserCapabilities   *UserCapabilities     `json:"user_capabilities"`
-	Project            *Project              `json:"project"`
-	Inventory          *Inventory            `json:"inventory"`
-	RecentJobs         []interface{}         `json:"recent_jobs"`
-	Groups             *Groups               `json:"groups"`
-	Credentials        []Credential          `json:"credentials"`
-	Credential         *Credential           `json:"credential"`
-	Labels             *Labels               `json:"labels"`
-	JobTemplate        *JobTemplateSummary   `json:"job_template"`
-	UnifiedJobTemplate *UnifiedJobTemplate   `json:"unified_job_template"`
-	ExtraCredentials   []interface{}         `json:"extra_credentials"`
-	ProjectUpdate      *ProjectUpdate        `json:"project_update"`
+	InstanceGroup      *InstanceGroupSummary  `json:"instance_group"`
+	Organization       *OrgnizationSummary    `json:"organization"`
+	CreatedBy          *ByUserSummary         `json:"created_by"`
+	ModifiedBy         *ByUserSummary         `json:"modified_by"`
+	ObjectRoles        *ObjectRoles           `json:"object_roles"`
+	UserCapabilities   *UserCapabilities      `json:"user_capabilities"`
+	Project            *Project               `json:"project"`
+	LastJob            map[string]interface{} `json:"last_job"`
+	CurrentJob         map[string]interface{} `json:"current_job"`
+	LastUpdate         map[string]interface{} `json:"last_update"`
+	Inventory          *Inventory             `json:"inventory"`
+	RecentJobs         []interface{}          `json:"recent_jobs"`
+	Groups             *Groups                `json:"groups"`
+	Credentials        []Credential           `json:"credentials"`
+	Credential         *Credential            `json:"credential"`
+	Labels             *Labels                `json:"labels"`
+	JobTemplate        *JobTemplateSummary    `json:"job_template"`
+	UnifiedJobTemplate *UnifiedJobTemplate    `json:"unified_job_template"`
+	ExtraCredentials   []interface{}          `json:"extra_credentials"`
+	ProjectUpdate      *ProjectUpdate         `json:"project_update"`
 }
 
 // ProjectUpdate represents the awx api project update.


### PR DESCRIPTION
The commit adds the capabilities required to query the project api
    to gather the information about the Project Updates jobs. It's
    to perform graceful project delete through API.
    
    Added:
      * current_job, last_job and last_update to the Summary struct
      * add CancelUpdate and GetUpdate Project Services functions